### PR TITLE
Fix URL to reflect HTTP server from main.go

### DIFF
--- a/section02/README.md
+++ b/section02/README.md
@@ -175,7 +175,7 @@ Try it:
 
 	$ go run main.go
 
-And then visit https://127.0.0.1/hello.
+And then visit http://127.0.0.1:8080/hello.
 
 ### Exercise Bye, web
 


### PR DESCRIPTION
The link in the documentation used incorrect protocol (https) and incorrect port (implied 443).
