### PR TITLE
Replace io.ReadAll with ioutil.ReadAll

### DIFF
--- a/section03/README.md
+++ b/section03/README.md
@@ -54,7 +54,7 @@ the body of the `http.Request`.
 Note that even though the type of `Body` in `http.Request` is `io.ReadCloser` the body will be automatically
 closed at the end of the execution of the http handler, so don't worry about it.
 
-There's many ways we can read from an `io.Reader`, but for now you can use `io.ReadAll`,
+There's many ways we can read from an `io.Reader`, but for now you can use `ioutil.ReadAll`,
 which returns a `[]byte` and an `error` if something goes wrong.
 
 ### Exercise Hello, body


### PR DESCRIPTION
Fixed typo from `io.ReadAll` to `ioutil.ReadAll`.
