### PR TITLE
Update README.md to make link to the home page of the popular Gorilla Toolkit Go Package actually work

### DIFF
--- a/section02/README.md
+++ b/section02/README.md
@@ -241,7 +241,7 @@ func main() {
 ```
 
 Gorilla also provides packages for session management, cookies, etc.
-Have a look at the [documentation](https://www.gorillatoolkit.org/).
+Have a look at the [documentation](www.gorillatoolkit.org/).
 
 #### Exercise Hello, {you}
 


### PR DESCRIPTION
For whatever reason, their DNS/routing settings only react to `www.gorillatoolkit.org` with the protocol prefix associated with `https` being omitted. 