### PR TITLE
'application' field is not used by gcloud

### DIFF
--- a/section04/README.md
+++ b/section04/README.md
@@ -170,10 +170,7 @@ project.
 1. Click on `create a project` and choose a name and project ID
 1. Run `gcloud init` and choose your recently created project. No need to set Compute zones.
 
-That's it! You can now deploy your code to the Google App Engine servers!
-
-Modify the `app.yaml` changing the `application` line to contain the project ID
-of the project you just created and deploy it running:
+That's it! You can now deploy your code to the Google App Engine servers:
 
 ```bash
 $ gcloud app deploy app.yaml


### PR DESCRIPTION
The [application] field is specified in file [.../app.yaml]. This field is not used by gcloud and must be removed. Project name should instead be specified either by gcloud config set project MY_PROJECT or by setting the --project flag on individual command executions.